### PR TITLE
Added Prerequisites for Utility Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,13 @@ export CFN_EXPORT_NAME_CLUSTER_NAME=EKSObservabilityDemoClusterName
 export CFN_EXPORT_NAME_OIDC_PROVIDER_ARN=EKSObservabilityDemoOIDCProviderArn
 export CFN_EXPORT_NAME_KUBECTL_ROLE_ARN=EKSObservabilityDemoKubectlRoleArn
 ```
+### Install Prerequisites for Utility Code
+
+```bash
+cd utils/
+## install prequisites for utility classes
+npm i
+```
 
 ### Create a cluster for this demo
 


### PR DESCRIPTION
If we dont do  **"npm i"** in the **utils** folder I received below error

```
TSError: ⨯ Unable to compile TypeScript:
../utils/cluster-utils.ts:1:22 - error TS2307: Cannot find module '@aws-cdk/core' or its corresponding type declarations.

1 import * as cdk from "@aws-cdk/core";
                       ~~~~~~~~~~~~~~~
../utils/cluster-utils.ts:2:22 - error TS2307: Cannot find module '@aws-cdk/aws-iam' or its corresponding type declarations.

2 import * as iam from "@aws-cdk/aws-iam";
                       ~~~~~~~~~~~~~~~~~~
../utils/cluster-utils.ts:3:22 - error TS2307: Cannot find module '@aws-cdk/aws-eks' or its corresponding type declarations.

3 import * as eks from "@aws-cdk/aws-eks";
                       ~~~~~~~~~~~~~~~~~~
```