### PR TITLE
adot configmap was referring to a non existent path

### DIFF
--- a/observability/lib/opentelemetry-stack.ts
+++ b/observability/lib/opentelemetry-stack.ts
@@ -38,7 +38,7 @@ export class OpenTelemetryStack extends cdk.Stack {
 
     // OpenTelemetry Agent
     const configMap = applyManifest(
-      path.resolve("dist/adot-configmap.yaml"), cluster);
+      path.resolve("resources/adot-configmap.yaml"), cluster);
     configMap.node.addDependency(namespace);
 
     const daemonSet = applyManifest(


### PR DESCRIPTION
*Issue #, if available:*
It was failing while applying the observability stacks
*Description of changes:*
Updated the path for the adot-configmap.yaml file

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
